### PR TITLE
曲の提案機能の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -58,9 +58,10 @@ body:before {
 }
 
 // top.html.erb
-.text-center {
-    text-align: center;
-    color: white;
+.container {
+    color: #fff;
+    margin-top: 20px;
+    margin-bottom: 50px;
 }
 
 .cover {
@@ -110,7 +111,7 @@ body:before {
     text-decoration: none;
     background-color: rgba(0, 0, 0, 0.8);
     max-width: 80%;
-    padding: 15px 30px;
+    padding: 20px 30px;
 }
 
 .button:hover {
@@ -150,6 +151,10 @@ footer {
     text-align: center;
 }
 
+.analysis-btn {
+    margin-top: 20px;
+}
+
 .emotion {
     font-size: 20px;
     font-weight: bold;
@@ -160,7 +165,8 @@ footer {
 }
 
 .btn-2 {
-    text-align: center;
+    display: flex;
+    justify-content: center;
 }
 
 /* ボタン */
@@ -171,12 +177,100 @@ footer {
     border: 2px solid #fff;
     text-decoration: none;
     background-color: rgba(0, 0, 0, 0.8);
-    max-width: 80%;
-    padding: 15px 30px;
-    margin-top: 30px;
+    padding: 15px 20px;
+    margin: 20px 30px;
 }
 
 .button-2:hover {
+    background:  rgba(255, 255, 255, 0.8);
+    color: #000;
+    border: 2px solid #000;
+}
+
+// result_show.html.erb
+.result_emotion, .result_song {
+    text-shadow: 3px 3px 3px #000;
+}
+
+.result_emotion {
+    border: outset 2px rgba(255, 255, 255, 0.9);
+    border-radius: 10px;
+    background-color: rgba(127, 127, 127, 0.9);
+    display: flex;
+    padding: 30px 70px;
+}
+
+.result_emotion img {
+    margin: auto;
+}
+
+.result_emotion p {
+    font-size: 18px;
+    margin: auto;
+}
+
+.result_song h4 {
+    padding: 0 10px;
+    margin: 40px 0 30px 0;
+}
+
+.result_song p {
+    font-size: 20px;
+    margin-top: 16px;
+}
+
+.result_song audio {
+    margin: auto;
+}
+
+.song_info {
+    display: flex;
+    margin: 10px auto;
+}
+
+.card {
+    background-color: rgba(50, 50, 50, 0.9) !important;
+    padding: 50px 30px;
+}
+
+.btn-3 {
+    display: flex;
+    justify-content: center;
+    margin-top: 20px;
+}
+
+/* ボタン */
+.button-3 {
+    font-size: 14px;
+    font-weight: bold;
+    color: #fff;
+    border: 2px solid #fff;
+    text-decoration: none;
+    background-color: rgba(0, 0, 0, 0.8);
+    max-width: 80%;
+    padding: 15px 13px 15px 17px;
+    margin: 20px 50px;
+}
+
+.button-3:hover {
+    background:  rgba(255, 255, 255, 0.8);
+    color: #000;
+    border: 2px solid #000;
+}
+
+.button-4 {
+    font-size: 14px;
+    font-weight: bold;
+    color: #fff;
+    border: 2px solid #fff;
+    text-decoration: none;
+    background-color: rgba(0, 0, 0, 0.8);
+    max-width: 80%;
+    padding: 15px 30px;
+    margin: 20px 50px;
+}
+
+.button-4:hover {
     background:  rgba(255, 255, 255, 0.8);
     color: #000;
     border: 2px solid #000;
@@ -214,8 +308,9 @@ footer {
 }
 
 .spotify {
+    font-size: 20px;
     margin-left: 5px;
-    margin-top: 18px;
+    margin-top: 16px;
 }
 
 .img-pre {
@@ -243,7 +338,7 @@ footer {
 }
 
 .result {
-    margin-top: 50px;
+    margin-top: 40px;
 }
 
 .album {
@@ -255,21 +350,23 @@ footer {
 }
 
 .track {
-    padding: 0 7rem;
+   padding: 0 8rem;
 }
 
 .row {
     font-size: 20px;
-    display: flex;
-    padding-left: 50px;
+}
+
+.track_name {
+    width: 310px !important;
 }
 
 .track p {
-    margin-top: 3px;
+    margin-top: 5px;
 }
 
 .form {
-    margin: 0 0 0 auto;
+    width: 60px !important;
 }
 
 // song_search.html.erb
@@ -294,12 +391,6 @@ footer {
 .row2 {
     display: flex;
     flex-wrap: wrap;
-}
-
-.card {
-    background-color: #242424d3 !important;
-    padding: 1.5rem 1rem;
-    margin: 0 10px;
 }
 
 /* スマホ対応 */

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -3,7 +3,7 @@ class SongsController < ApplicationController
   RSpotify.authenticate(ENV['SPOTIFY_CLIENT_ID'], ENV['SPOTIFY_SECRET_ID'])
 
   def index
-    @songs = Song.all
+    @songs = Song.all.includes(:result)
   end
 
   def new

--- a/app/views/home/top.html.erb
+++ b/app/views/home/top.html.erb
@@ -1,10 +1,12 @@
 <div class="cover-container d-flex w-100 h-100 p-3 mx-auto flex-column">
   <main role="main" class="inner cover text-center">
-    <h1 class="cover-heading">your song</h1>
-    <div class="cover2">
-      <p class="lead">今のあなたにぴったりな曲を見つけよう!</p>
-      <%= link_to "さっそくはじめる", new_result_path, class:"custom-btn button"  %>
+    <div class="container">
+      <h1 class="cover-heading">your song</h1>
+      <div class="cover2">
+        <p class="lead">今のあなたにぴったりな曲を見つけよう!</p>
+        <%= link_to "さっそくはじめる", new_result_path, class:"custom-btn button" %>
+      </div>
+      <p class="ps">※本アプリは、SUPER BEAVER の楽曲のみの提案になります。</p>
     </div>
-    <p class="ps">※本アプリは、SUPER BEAVER の楽曲のみの提案になります。</p>
   </main>
 </div>

--- a/app/views/results/new.html.erb
+++ b/app/views/results/new.html.erb
@@ -1,21 +1,24 @@
 <div class="cover-container d-flex mx-auto flex-column">
-  <div class="camera">
-    <video id="video" width="400" height="300" autoplay="1" playsinline></video>
-    <canvas id="canvas" width="400" height="300"></canvas>
-  </div>
-  <div class="btn">  
-    <button class="button-2" id="analysis">診断する</button>
-  </div>
-  <div class="emotion">
-    <p id="result"></p>
-  </div>
-  <div class="btn-2">
-    <button class="button-2" id="reload">撮り直す</button>
-    <%= form_with model: @result, local: true do |f| %>
-      <%= f.hidden_field :image, id: "photo" %>
-      <%= f.hidden_field :emotion, id: "emotion" %>
-      <%= f.submit  "判定結果", class: "button-2", id: "song" %>
-    <% end %>
+  <div class="container text-center">
+    <div class="camera">
+      <video id="video" width="400" height="300" autoplay="1" playsinline></video>
+      <canvas id="canvas" width="400" height="300"></canvas>
+    </div>
+    <div class="analysis-btn">  
+      <button class="button-2" id="analysis">診断する</button>
+    </div>
+    <div class="emotion">
+      <p id="result"></p>
+    </div>
+    <div class="btn-2">
+      <button class="button-2" id="reload">撮り直す</button>
+      <%= form_with model: @result, local: true do |f| %>
+        <%= f.hidden_field :image, id: "photo" %>
+        <%= f.hidden_field :emotion, id: "emotion" %>
+        <%= f.hidden_field :song_id, id: "song_id" %>
+        <%= f.submit  "判定結果", class: "button-2", id: "song" %>
+      <% end %>
+    </div>
   </div>
 </div>
 
@@ -61,9 +64,12 @@
         $('#reload').show();
         $('#song').show();
         document.getElementById("emotion").value = data.emotion;
+        document.getElementById("song_id").value = data.song_id;
       },
-      error: function (XMLHttpRequest, textStatus, errorThrown) {
-        console.log("失敗")
+      error: function() {
+        $('#result').append("分析失敗しました(>_<)");
+        $('#reload').show();
+        $('#analysis').hide();
       }
     });
   })

--- a/app/views/results/show.html.erb
+++ b/app/views/results/show.html.erb
@@ -1,3 +1,29 @@
 <div class="cover-container d-flex mx-auto flex-column">
-  <p><%= @result.emotion %></p>
+  <div class="container">
+    <div class="result_emotion">
+      <img src="<%= "data:image/png;base64,#{@result.image}" %>" width="100" height="80">
+      <p>あなたの感情 : <%= @result.emotion %></p>
+    </div>
+
+    <div class="result_song">
+      <h4>↓そんなあなたにおすすめの曲がこちらです↓</h4>
+      <div class="card">
+        <img src="<%= "#{@result.song.album_image}" %>", class="d-block mx-auto" width="150" height="150">
+        <div class="song_info">
+          <p><%= @result.song.title %></p>
+          <%= link_to "#{@result.song.spotify_url}", class: "spotify" do %>
+            <i class="fa-brands fa-spotify" style = "color: green"></i>
+          <% end %>
+        </div>
+          <audio controls src="<%= "#{@result.song.preview_url}" %>" style="width: 400px;"></audio>
+      </div>
+    </div>
+
+    <div class="btn-3">
+      <%= link_to "#", class: "twitter button-3" do %>
+        <i class="fa-brands fa-twitter"></i> つぶやく
+      <% end %>
+      <%= link_to "ホーム", root_path, class:"button-4" %>
+    </div>
+  </div>
 </div>

--- a/app/views/songs/new.html.erb
+++ b/app/views/songs/new.html.erb
@@ -23,7 +23,9 @@
           <div class="track">
             <% @album.tracks.each do |track| %>
               <div class="row">
-                <p><%= track.name %></p>
+                <div class="track_name">
+                  <p><%= track.name %></p>
+                </div>
                 <div class="form">
                   <%= form_with model: @song, local: true do |f| %>
                     <%= f.hidden_field :artist, value: track.artists[0].name %>

--- a/app/views/songs/search.html.erb
+++ b/app/views/songs/search.html.erb
@@ -18,7 +18,8 @@
                 <p class="artist"><%= album.artists[0].name %></p>
               </div>
               <% album.tracks.each do |track|  %>
-                <%= track.name %><br>
+                <%= track.name %>
+                <%= track.audio_features.danceability %><br>
               <% end %>
               <br>
             </div>


### PR DESCRIPTION
## 概要
### 曲の提案結果画面の実装。
result_contorollerにて、感情ごとにどの曲が提案されるかのコードを追加した。
spotify APIから取得したデータから、この値が〇〇以上もしくは以下の曲を取得し、その中からランダムで曲を取り出すようにした。