### PR TITLE
ユーザー登録失敗時、個別にエラーメッセージが表示されるように実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,6 +19,11 @@
 * {
     font-family: 'Spectral', serif;
 }
+
+.field_with_errors {
+    display: contents;
+}
+
 // application.html.erb
 body {
     display: flex;

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -20,7 +20,7 @@ class PostsController < ApplicationController
       redirect_to posts_path, success: "投稿しました！"
     else
       flash.now[:danger] = "投稿に失敗しました！"
-      render search_posts_path
+      render :search
     end
   end
 

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div id="error_messages" class="alert alert-danger">
+    <ul class="mb-0">
+      <% object.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,6 +1,6 @@
 <div class="cover-container d-flex mx-auto mt-auto flex-column">
   <div class="login_card">
-    <h4 class="text-center">ログイン</h4>
+    <h4 class="text-center"><i class="fa-solid fa-right-to-bracket"></i> ログイン</h4>
     <div class="login_form">
       <%= form_with url: login_path, local: true do |f| %>
         <div class="form-group">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,16 +1,17 @@
 <div class="cover-container d-flex mx-auto mt-auto flex-column">
   <div class="login_card">
-    <h4 class="text-center"><i class="fa-regular fa-user"></i>ユーザー登録</h4>
+    <h4 class="text-center"><i class="fa-regular fa-user"></i> ユーザー登録</h4>
     <div class="login_form">
       <%= form_with model: @user, local: true do |f| %>
+        <%= render 'shared/error_messages', object: f.object %>
         <div class="form-group">
           <i class="fa-regular fa-user"></i>
-          <%= f.label :name, "ユーザー名"%>
+          <%= f.label :name %>
           <%= f.text_field :name, class: 'form-control' %>
         </div>
         <div class="form-group">
           <i class="fa-regular fa-envelope"></i>
-          <%= f.label :email, "メールアドレス"%>
+          <%= f.label :email %>
           <%= f.email_field :email, class: 'form-control' %>
         </div>
         <div class="form-group">
@@ -20,12 +21,12 @@
         </div>
         <div class="form-group">
           <i class="fa-solid fa-lock"></i>
-          <%= f.label :password, "パスワード" %>
+          <%= f.label :password %>
           <%= f.password_field :password, class: 'form-control' %>
         </div>
         <div class="form-group">
           <i class="fa-solid fa-lock"></i>
-          <%= f.label :password_confirmation, "パスワード確認" %>
+          <%= f.label :password_confirmation %>
           <%= f.password_field :password_confirmation, class: 'form-control' %>
         </div>
         <div class="register_button">

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -1,0 +1,11 @@
+ja:
+  activerecord:
+    models:
+      user: 'ユーザー'
+      post: '投稿'
+    attributes:
+      user:
+        email: 'メールアドレス'
+        password: 'パスワード'
+        password_confirmation: 'パスワード確認'
+        name: 'ユーザー名'


### PR DESCRIPTION
## 概要
ユーザー登録失敗時、個別にエラーメッセージが表示されるように実装した。
失敗時に、エラーメッセージが表示されるとレイアウトが崩れる(field_with_errorsクラスが付与される為)ため、崩れないように`display: contents;`を設定した。